### PR TITLE
[RedDwarf] Add regression tests for the landing page

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  driven_by :rack_test
+end

--- a/test/system/landing_page_test.rb
+++ b/test/system/landing_page_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class LandingPageTest < ApplicationSystemTestCase
+  test "root landing page renders all required section headings" do
+    visit root_path
+
+    assert_text "Build strength, confidence, and habits that actually fit your life."
+    assert_text "A complete formula for sustainable fitness."
+    assert_text "Your plan, your pace, expert eyes every step."
+    assert_text "Show up for the room. Leave stronger for yourself."
+    assert_text "Fuel that supports real life."
+    assert_text "Members feel the difference in and out of the gym."
+    assert_text "Ready to find your formula?"
+  end
+end


### PR DESCRIPTION
## RedDwarf SCM Handoff

- Task ID: derekrivers-automerge-syndrome-9-ticket-3
- Run ID: c8a4cb2a-9d54-48eb-9198-320d8163ccae
- Base branch: main
- Head branch: reddwarf/derekrivers-automerge-syndrome-9-ticket-3/scm
- Validation report: workspace://derekrivers-automerge-syndrome-9-ticket-3-workspace/artifacts/validation-report.md

### Summary

Add automated test coverage for the root landing page. At minimum, include one system test that visits `/` and asserts that each required section heading is present in the rendered HTML. Keep the test stable by asserting visible, user-facing section headings rather than implementation-specific CSS classes.

### Validation

Run deterministic lint and test checks for workspace derekrivers-automerge-syndrome-9-ticket-3-workspace before review or SCM handoff.

### Acceptance Criteria

- A system test visits `/` successfully.
- The system test asserts headings/content for all seven landing-page sections.
- `bin/rails test` passes from a clean checkout.
- Test setup is compatible with the generated Rails 7 application and does not require external services or production credentials.

<!-- reddwarf:ticket_id:project:derekrivers-automerge-syndrome-9:ticket:3 -->
