### PR TITLE
[RedDwarf] Add Kamal deployment configuration for DigitalOcean

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,27 @@ Run RuboCop:
 bundle exec rubocop
 ```
 
+## Deployment with Kamal on DigitalOcean
+
+`config/deploy.yml` contains a reviewable Kamal configuration for deploying this Rails app to a DigitalOcean droplet with images stored in DigitalOcean Container Registry. The file intentionally uses placeholders instead of production values or credentials.
+
+Before deploying, replace these placeholders with environment-specific values:
+
+- `<KAMAL_APP_NAME>`: the Kamal service/app name, for example `fitnessformula`.
+- `<DO_REGISTRY_NAME>` and `<DO_IMAGE_NAME>`: the DigitalOcean Container Registry name and image repository.
+- `<DROPLET_IP>`: the target DigitalOcean droplet IP address.
+- `<PRODUCTION_HOSTNAME>`: the hostname Kamal Proxy should terminate SSL for.
+- `<DO_REGISTRY_USERNAME>`: the registry username or token username expected by DigitalOcean.
+
+Provide sensitive values through the deploy environment rather than committing them:
+
+```sh
+export KAMAL_REGISTRY_PASSWORD=<DO_REGISTRY_PASSWORD>
+export RAILS_MASTER_KEY=<PRODUCTION_RAILS_MASTER_KEY>
+```
+
+The Kamal config enables Rails production defaults needed by this app (`RAILS_ENV`, static file serving, stdout logging, and thread count), persists `storage/` for the SQLite production database and uploaded files, and sets `asset_path: /rails/public/assets` so compiled Rails/Tailwind assets remain compatible with production deploys. Run `bin/rails tailwindcss:build` locally when validating asset changes before a deploy.
+
 ## Selected design direction
 
 FitnessFormula is presented as a confident, premium fitness brand with a direct path from interest to action. The page structure uses:

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -1,0 +1,43 @@
+# Kamal deployment configuration for DigitalOcean.
+# Replace every angle-bracket placeholder before deploying. Do not commit real
+# registry passwords, droplet addresses, Rails master keys, or production secrets.
+
+service: "<KAMAL_APP_NAME>"
+
+image: "registry.digitalocean.com/<DO_REGISTRY_NAME>/<DO_IMAGE_NAME>"
+
+servers:
+  web:
+    hosts:
+      - "<DROPLET_IP>"
+
+proxy:
+  ssl: true
+  host: "<PRODUCTION_HOSTNAME>"
+  app_port: 3000
+
+registry:
+  server: registry.digitalocean.com
+  username: "<DO_REGISTRY_USERNAME>"
+  password:
+    - KAMAL_REGISTRY_PASSWORD # export as <DO_REGISTRY_PASSWORD> in the deploy environment
+
+env:
+  clear:
+    RAILS_ENV: production
+    RAILS_SERVE_STATIC_FILES: "true"
+    RAILS_LOG_TO_STDOUT: "true"
+    RAILS_MAX_THREADS: "5"
+  secret:
+    - RAILS_MASTER_KEY # set to the production credentials key, never a real value in this file
+
+builder:
+  arch: amd64
+
+# Persist the Rails SQLite database, Active Storage files, logs, and other runtime
+# files across container replacements on the droplet.
+volumes:
+  - "<KAMAL_APP_NAME>_storage:/rails/storage"
+
+# Keep compiled Rails/Tailwind assets available across zero-downtime deploys.
+asset_path: /rails/public/assets


### PR DESCRIPTION
## RedDwarf SCM Handoff

- Task ID: derekrivers-automerge-syndrome-9-ticket-5
- Run ID: 9b6edd87-7d15-4f33-a772-ab93fef33e1e
- Base branch: main
- Head branch: reddwarf/derekrivers-automerge-syndrome-9-ticket-5/scm
- Validation report: workspace://derekrivers-automerge-syndrome-9-ticket-5-workspace/artifacts/validation-report.md

### Summary

Add a Kamal deployment configuration suitable for deploying the Rails marketing site to a DigitalOcean droplet and DigitalOcean Container Registry. The configuration should be reviewable without real secrets and must mark sensitive or environment-specific values as placeholders. Include image registry, server host, app name, proxy/SSL assumptions where appropriate, and environment variables needed by a minimal Rails production deploy.

### Validation

Run deterministic lint and test checks for workspace derekrivers-automerge-syndrome-9-ticket-5-workspace before review or SCM handoff.

### Acceptance Criteria

- `config/deploy.yml` exists and is valid Kamal-style configuration for a Rails app deploy to a DigitalOcean droplet.
- Sensitive values and environment-specific settings are clearly placeholders, including examples such as `<DO_REGISTRY_PASSWORD>`, `<DROPLET_IP>`, registry/app names, and any required Rails secrets.
- The deployment configuration does not commit real credentials, tokens, droplet IPs, or production secrets.
- README deployment instructions reference the Kamal config and explain which placeholders must be replaced.
- The config remains compatible with production Tailwind asset compilation.

<!-- reddwarf:ticket_id:project:derekrivers-automerge-syndrome-9:ticket:5 -->
